### PR TITLE
Bugfix for Visual Studio error C2589 and C2059

### DIFF
--- a/src/windows_config.h
+++ b/src/windows_config.h
@@ -74,4 +74,8 @@
 
 #endif // HAVE_ENABLED
 
+#if _MSC_VER >= 1900
+#include <xlocnum>
+#endif
+
 #endif


### PR DESCRIPTION
Bugfix for Visual Studio error C2589 and C2059 in combination with fox toolkit 1.6.

Example for GUIManipulator.cpp:
> 1>  GUIManipulator.cpp
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(32): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(32): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(37): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(37): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(47): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(47): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(57): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(57): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(67): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(67): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(77): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(77): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(88): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(88): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(108): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(108): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(123): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(123): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(133): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(133): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(154): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(154): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(194): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(194): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(199): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(199): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(251): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(251): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(259): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(259): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(295): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(295): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(305): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(305): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(310): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\cmath(310): error C2059: Syntaxfehler: "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\xlocnum(82): error C2589: "(": Ungültiges Token auf der rechten Seite von "::"
> 1>c:\program files (x86)\microsoft visual studio 14.0\vc\include\xlocnum(82): error C2059: Syntaxfehler: "::"
> 