### PR TITLE
Ensure traci.connect() exits gracefully with python3

### DIFF
--- a/tools/traci/__init__.py
+++ b/tools/traci/__init__.py
@@ -58,7 +58,7 @@ def connect(port=8813, numRetries=10, host="localhost", proc=None):
             if wait < numRetries + 1:
                 print(" Retrying in %s seconds" % wait)
                 time.sleep(wait)
-    raise FatalTraCIError(str(e))
+    raise FatalTraCIError("Could not connect in %s tries" % (numRetries + 1))
 
 
 def init(port=8813, numRetries=10, host="localhost", label="default"):


### PR DESCRIPTION
Hello,

I have been using TraCI with python3 and noticed that the traci.connect() method raises an UnboundLocalError in case of repeated connection failures instead of the expected FatalTraCIError:

> \>>> import traci
\>>> traci.connect()
Could not connect to TraCI server at localhost:8813 [Errno 111] Connection refused
 Retrying in 1 seconds
Could not connect to TraCI server at localhost:8813 [Errno 111] Connection refused
 Retrying in 2 seconds
Could not connect to TraCI server at localhost:8813 [Errno 111] Connection refused
 Retrying in 3 seconds
Could not connect to TraCI server at localhost:8813 [Errno 111] Connection refused
 Retrying in 4 seconds
Could not connect to TraCI server at localhost:8813 [Errno 111] Connection refused
 Retrying in 5 seconds
Could not connect to TraCI server at localhost:8813 [Errno 111] Connection refused
 Retrying in 6 seconds
Could not connect to TraCI server at localhost:8813 [Errno 111] Connection refused
 Retrying in 7 seconds
Could not connect to TraCI server at localhost:8813 [Errno 111] Connection refused
 Retrying in 8 seconds
Could not connect to TraCI server at localhost:8813 [Errno 111] Connection refused
 Retrying in 9 seconds
Could not connect to TraCI server at localhost:8813 [Errno 111] Connection refused
 Retrying in 10 seconds
Could not connect to TraCI server at localhost:8813 [Errno 111] Connection refused
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ogg/dev/sumo/tools/traci/\__init__.py", line 61, in connect
    raise FatalTraCIError(str(e))
UnboundLocalError: local variable 'e' referenced before assignment

I see that the current implementation of connect() raises a fatal exception using the last socket error. This doesn't work in Python 3 because variables assigned to exceptions in the except cause are explicitly deleted after the except block (see [PEP 3110](https://www.python.org/dev/peps/pep-3110/)).

```
def connect(port=8813, numRetries=10, host="localhost", proc=None):
    """
    Establish a connection to a TraCI-Server and return the
    connection object. The connection is not saved in the pool and not
    accessible via traci.switch. It should be safe to use different
    connections established by this method in different threads.
    """
    for wait in range(1, numRetries + 2):
        try:
            return Connection(host, port, proc)
        except socket.error as e:
            print("Could not connect to TraCI server at %s:%s" %
                  (host, port), e)
            if wait < numRetries + 1:
                print(" Retrying in %s seconds" % wait)
                time.sleep(wait)
    raise FatalTraCIError(str(e))
```

One possible solution is to raise the FatalTraCIError with a custom message:
```
raise FatalTraCIError("Could not connect in %s tries" % (numRetries + 1))
```

Do let me know if I should open an issue for this instead.

Thanks!