### PR TITLE
Place turn defs within an interval element, fixes #3712

### DIFF
--- a/tests/tools/turndefs/generateTurnDefs/uniform_distribution/options.tools
+++ b/tests/tools/turndefs/generateTurnDefs/uniform_distribution/options.tools
@@ -1,1 +1,1 @@
---connections-file connections.con.xml --turn-definitions-file turn-defs.xml
+--connections-file connections.con.xml --turn-definitions-file turn-defs.xml --begin 100 --end 200

--- a/tests/tools/turndefs/generateTurnDefs/uniform_distribution/turndefs.tools
+++ b/tests/tools/turndefs/generateTurnDefs/uniform_distribution/turndefs.tools
@@ -1,50 +1,52 @@
 <turns xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/turns_file.xsd">
-    <fromEdge id="1fi">
-        <toEdge id="1si" probability="100"/>
-    </fromEdge>
-    <fromEdge id="1o">
-        <toEdge id="1fi" probability="100"/>
-    </fromEdge>
-    <fromEdge id="1si">
-        <toEdge id="1o" probability="25"/>
-        <toEdge id="2o" probability="25"/>
-        <toEdge id="3o" probability="25"/>
-        <toEdge id="4o" probability="25"/>
-    </fromEdge>
-    <fromEdge id="2fi">
-        <toEdge id="2si" probability="100"/>
-    </fromEdge>
-    <fromEdge id="2o">
-        <toEdge id="2fi" probability="100"/>
-    </fromEdge>
-    <fromEdge id="2si">
-        <toEdge id="1o" probability="41.66666667"/>
-        <toEdge id="2o" probability="16.66666667"/>
-        <toEdge id="3o" probability="16.66666667"/>
-        <toEdge id="4o" probability="25"/>
-    </fromEdge>
-    <fromEdge id="3fi">
-        <toEdge id="3si" probability="100"/>
-    </fromEdge>
-    <fromEdge id="3o">
-        <toEdge id="3fi" probability="100"/>
-    </fromEdge>
-    <fromEdge id="3si">
-        <toEdge id="1o" probability="50"/>
-        <toEdge id="2o" probability="16.66666667"/>
-        <toEdge id="3o" probability="16.66666667"/>
-        <toEdge id="4o" probability="16.66666667"/>
-    </fromEdge>
-    <fromEdge id="4fi">
-        <toEdge id="4si" probability="100"/>
-    </fromEdge>
-    <fromEdge id="4o">
-        <toEdge id="4fi" probability="100"/>
-    </fromEdge>
-    <fromEdge id="4si">
-        <toEdge id="1o" probability="50"/>
-        <toEdge id="2o" probability="12.5"/>
-        <toEdge id="3o" probability="25"/>
-        <toEdge id="4o" probability="12.5"/>
-    </fromEdge>
+    <interval begin="100" end="200">
+        <fromEdge id="1fi">
+            <toEdge id="1si" probability="100"/>
+        </fromEdge>
+        <fromEdge id="1o">
+            <toEdge id="1fi" probability="100"/>
+        </fromEdge>
+        <fromEdge id="1si">
+            <toEdge id="1o" probability="25"/>
+            <toEdge id="2o" probability="25"/>
+            <toEdge id="3o" probability="25"/>
+            <toEdge id="4o" probability="25"/>
+        </fromEdge>
+        <fromEdge id="2fi">
+            <toEdge id="2si" probability="100"/>
+        </fromEdge>
+        <fromEdge id="2o">
+            <toEdge id="2fi" probability="100"/>
+        </fromEdge>
+        <fromEdge id="2si">
+            <toEdge id="1o" probability="41.66666667"/>
+            <toEdge id="2o" probability="16.66666667"/>
+            <toEdge id="3o" probability="16.66666667"/>
+            <toEdge id="4o" probability="25"/>
+        </fromEdge>
+        <fromEdge id="3fi">
+            <toEdge id="3si" probability="100"/>
+        </fromEdge>
+        <fromEdge id="3o">
+            <toEdge id="3fi" probability="100"/>
+        </fromEdge>
+        <fromEdge id="3si">
+            <toEdge id="1o" probability="50"/>
+            <toEdge id="2o" probability="16.66666667"/>
+            <toEdge id="3o" probability="16.66666667"/>
+            <toEdge id="4o" probability="16.66666667"/>
+        </fromEdge>
+        <fromEdge id="4fi">
+            <toEdge id="4si" probability="100"/>
+        </fromEdge>
+        <fromEdge id="4o">
+            <toEdge id="4fi" probability="100"/>
+        </fromEdge>
+        <fromEdge id="4si">
+            <toEdge id="1o" probability="50"/>
+            <toEdge id="2o" probability="12.5"/>
+            <toEdge id="3o" probability="25"/>
+            <toEdge id="4o" probability="12.5"/>
+        </fromEdge>
+    </interval>
 </turns>

--- a/tools/turn-defs/generateTurnDefs.py
+++ b/tools/turn-defs/generateTurnDefs.py
@@ -38,8 +38,16 @@ if __name__ == "__main__":
     option_parser.add_option("-t", "--turn-definitions-file",
                              dest="turn_definitions_file",
                              help="Write the resulting turn definitions to TURN_DEFINITIONS_FILE. "
-                             "Mandatory.",
+                                  "Mandatory.",
                              metavar="TURN_DEFINITIONS_FILE")
+    option_parser.add_option("-b", "--begin",
+                             help="Generate turn definitions for interval starting at BEGIN seconds. "
+                                  "Defaults to 0.",
+                             default="0")
+    option_parser.add_option("-e", "--end",
+                             help="Generate turn definitions for interval ending at END seconds. "
+                                  "Defaults to 3600.",
+                             default="3600")
 
     (options, args) = option_parser.parse_args()
 
@@ -58,7 +66,9 @@ if __name__ == "__main__":
 
     connections = connections.from_stream(connections_file)
     turn_definitions = turndefinitions.from_connections(connections)
-    turn_definitions_xml = turndefinitions.to_xml(turn_definitions)
+    turn_definitions_xml = turndefinitions.to_xml(turn_definitions,
+                                                  options.begin,
+                                                  options.end)
     turn_definitions_file.write(turn_definitions_xml)
 
     connections_file.close()

--- a/tools/turn-defs/turndefinitions.py
+++ b/tools/turn-defs/turndefinitions.py
@@ -114,7 +114,7 @@ def from_connections(input_connections):
     return turn_definitions
 
 
-def to_xml(turn_definitions):
+def to_xml(turn_definitions, begin, end):
     """ Transforms the given TurnDefinitions object into a string
         containing a valid SUMO turn-definitions file. """
 
@@ -123,10 +123,15 @@ def to_xml(turn_definitions):
                  (len(turn_definitions.get_sources())))
 
     turn_definitions_xml = sumolib.xml.create_document("turns")
+
+    interval_element = turn_definitions_xml.addChild("interval")
+    interval_element.setAttribute("begin", begin)
+    interval_element.setAttribute("end", end)
+
     for source in turn_definitions.get_sources():
         LOGGER.debug("Converting turn definition with source %s" % (source))
 
-        from_edge_element = turn_definitions_xml.addChild("fromEdge", {"id": source})
+        from_edge_element = interval_element.addChild("fromEdge", {"id": source})
 
         for destination in turn_definitions.get_destinations(source):
             probability = turn_definitions.get_turning_probability(source,


### PR DESCRIPTION
Hello,

Here are the changes I've made to ensure generateTurnDefs.py generates turn defs files with the correct schema:

- Update turndefinitions.to_xml() to place the turn definitions within an interval element
- Add interval begin (default 0) and end (default 3600) times as command-line options to generateTurnDefs.py
- Update the generateTurnDefs/uniform_distribution test accordingly (both the options and the expected turn definitions)

Does this seem all right?