### PR TITLE
add traci functionality to get collision count

### DIFF
--- a/src/traci-server/TraCIConstants.h
+++ b/src/traci-server/TraCIConstants.h
@@ -830,6 +830,9 @@
 // ids of vehicles ending to park (get: simulation)
 #define VAR_PARKING_ENDING_VEHICLES_IDS 0x6f
 
+// number of collisions occurred (get: simulation)
+#define VAR_COLLISIONS_NUMBER 0x7f
+
 // clears the simulation of all not inserted vehicles (set: simulation)
 #define CMD_CLEAR_PENDING_VEHICLES 0x94
 
@@ -838,7 +841,6 @@
 
 // sets/retrieves abstract parameter
 #define VAR_PARAMETER 0x7e
-
 
 // add an instance (poi, polygon, vehicle, person, route)
 #define ADD 0x80

--- a/src/traci-server/TraCIServerAPI_Simulation.cpp
+++ b/src/traci-server/TraCIServerAPI_Simulation.cpp
@@ -74,6 +74,7 @@ TraCIServerAPI_Simulation::processGet(TraCIServer& server, tcpip::Storage& input
             && variable != VAR_PARKING_ENDING_VEHICLES_NUMBER && variable != VAR_PARKING_ENDING_VEHICLES_IDS
             && variable != VAR_STOP_STARTING_VEHICLES_NUMBER && variable != VAR_STOP_STARTING_VEHICLES_IDS
             && variable != VAR_STOP_ENDING_VEHICLES_NUMBER && variable != VAR_STOP_ENDING_VEHICLES_IDS
+            && variable != VAR_COLLISIONS_NUMBER
             && variable != VAR_PARAMETER
        ) {
         return server.writeErrorStatusCmd(CMD_GET_SIM_VARIABLE, "Get Simulation Variable: unsupported variable " + toHex(variable, 2) + " specified", outputStorage);
@@ -145,6 +146,11 @@ TraCIServerAPI_Simulation::processGet(TraCIServer& server, tcpip::Storage& input
             case VAR_STOP_ENDING_VEHICLES_IDS:
                 writeVehicleStateIDs(server, tempMsg, MSNet::VEHICLE_STATE_ENDING_STOP);
                 break;
+            case VAR_COLLISIONS_NUMBER: {
+                tempMsg.writeUnsignedByte(TYPE_INTEGER);
+                tempMsg.writeInt(MSNet::getInstance()->getVehicleControl().getCollisionCount());
+                break;
+            }
             case VAR_DELTA_T:
                 tempMsg.writeUnsignedByte(TYPE_INTEGER);
                 tempMsg.writeInt((int)libsumo::Simulation::getDeltaT());

--- a/tools/traci/_simulation.py
+++ b/tools/traci/_simulation.py
@@ -55,6 +55,7 @@ _RETURN_VALUE_FUNC = {tc.VAR_TIME_STEP: Storage.readInt,
                       tc.VAR_TELEPORT_STARTING_VEHICLES_IDS: Storage.readStringList,
                       tc.VAR_TELEPORT_ENDING_VEHICLES_NUMBER: Storage.readInt,
                       tc.VAR_TELEPORT_ENDING_VEHICLES_IDS: Storage.readStringList,
+                      tc.VAR_COLLISIONS_NUMBER: Storage.readInt,
                       tc.VAR_DELTA_T: Storage.readInt,
                       tc.VAR_NET_BOUNDING_BOX: lambda result: (result.read("!dd"), result.read("!dd"))}
 
@@ -217,6 +218,13 @@ class SimulationDomain(Domain):
         Returns a list of ids of vehicles which ended to be teleported in this time step.
         """
         return self._getUniversal(tc.VAR_TELEPORT_ENDING_VEHICLES_IDS)
+
+    def getCollisionsNumber(self):
+        """getCollisionsNumber() -> integer
+
+        A positive value indicates that collision(s) has occurred, doesn't necessarily mean the actual number of collisions.  
+        """
+        return self._getUniversal(tc.VAR_COLLISIONS_NUMBER)
 
     def getDeltaT(self):
         """getDeltaT() -> integer

--- a/tools/traci/constants.py
+++ b/tools/traci/constants.py
@@ -818,6 +818,9 @@ VAR_PARKING_ENDING_VEHICLES_NUMBER = 0x6e
 #  ids of vehicles ending to park (get: simulation)
 VAR_PARKING_ENDING_VEHICLES_IDS = 0x6f
 
+# number of collisions occurred (get: simulation)
+VAR_COLLISIONS_NUMBER = 0x7f
+
 #  clears the simulation of all not inserted vehicles (set: simulation)
 CMD_CLEAR_PENDING_VEHICLES = 0x94
 


### PR DESCRIPTION
It's useful to know whether collisions have occurred through traci when training self-driving cars under SUMO.