### PR TITLE
Fixed a copy command (re #3836)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,9 +152,9 @@ if (MSVC)
             GIT_REPOSITORY    http://gitlab.onelab.info/gl2ps/gl2ps.git
             GIT_TAG           gl2ps_1_4_0
             PREFIX            "${CMAKE_BINARY_DIR}/gl2ps"
-            INSTALL_COMMAND   cp "${CMAKE_BINARY_DIR}/gl2ps/src/gl2ps-build/Release/gl2ps.dll" "${CMAKE_SOURCE_DIR}/bin"
+            INSTALL_COMMAND   "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_BINARY_DIR}/gl2ps/src/gl2ps-build/$<CONFIG>/gl2ps.dll" "${CMAKE_SOURCE_DIR}/bin/gl2ps.dll"
         )
-        FIND_LIBRARY(GL2PS_LIBRARY NAMES gl2ps PATHS "${CMAKE_BINARY_DIR}/gl2ps/src/gl2ps-build/Release")
+        FIND_LIBRARY(GL2PS_LIBRARY NAMES gl2ps PATHS "${CMAKE_BINARY_DIR}/gl2ps/src/gl2ps-build/Release" "${CMAKE_BINARY_DIR}/gl2ps/src/gl2ps-build/Debug")
         if (GL2PS_LIBRARY)
             include_directories("${CMAKE_BINARY_DIR}/gl2ps/src/gl2ps")
             set(GL2PS_LIBRARIES ${GL2PS_LIBRARY})


### PR DESCRIPTION
The build error in #3836 is caused by the command `cp`, which supposedly only works on Windows when cygwin is installed . The usual command to copy files on Windows is `copy`. However, `copy` does not work properly when paths contain slashes. I therefore replaced the copy command with the CMake built-in copy command. I also added `$<CONFIG>` to the path, as otherwise the command will fail if Sumo isn't compiled in Release mode.

For the same reason, I added the path to the Debug build in the following `FIND_LIBRARY`call.

However, there is another issue with the inclusion of GL2PS on Windows, as `HAVE_GL2PS` is only going to be set to 1 after manually re-running CMake after an initial build of GL2PS. But I think that warrants a new separate issue.