### PR TITLE
Fixed missing <iterator> includes (Visual Studio)

### DIFF
--- a/src/libsumo/Edge.cpp
+++ b/src/libsumo/Edge.cpp
@@ -15,7 +15,7 @@
 // C++ TraCI client API implementation
 /****************************************************************************/
 
-
+#include <iterator>
 #include <microsim/MSEdge.h>
 #include <microsim/MSLane.h>
 #include <microsim/MSEdgeWeightsStorage.h>

--- a/src/netedit/GNENet.cpp
+++ b/src/netedit/GNENet.cpp
@@ -33,6 +33,7 @@
 #include <config.h>
 #endif
 
+#include <iterator>
 #include <map>
 #include <set>
 #include <vector>


### PR DESCRIPTION
Compilation with VS 2015 currently fails as `std::back_inserter` is undefinded in Edge.cpp https://github.com/DLR-TS/sumo/blob/3c7cf4a20ebcbf63d790b8df8c773126ae37b42f/src/libsumo/Edge.cpp#L316 and GNENet.cpp https://github.com/DLR-TS/sumo/blob/3c7cf4a20ebcbf63d790b8df8c773126ae37b42f/src/netedit/GNENet.cpp#L1611
`std::back_inserter` is defined in `<iterator>`, which seems to be indirectly included by other headers with other compilers, but not for Visual Studio.
For Visual Studio, `<iterator>`  was indirectly included by `Edge.cpp` via `MSEdge.h`-> `MSNet.h` -> `PedestrianRouter.h` -> `DijkstraRouter.h` until commit 7a80ea7. In `GNENet.cpp`, `std::back_inserter` was introduced with commit c7fce4e.
Explicitly including `<iterator>` fixes the compilation errors.