### PR TITLE
sumolib net reading now parses optional lane width attribute

### DIFF
--- a/tools/sumolib/net/__init__.py
+++ b/tools/sumolib/net/__init__.py
@@ -175,8 +175,9 @@ class Net:
             self._id2edge[id] = e
         return self._id2edge[id]
 
-    def addLane(self, edge, speed, length, allow=None, disallow=None):
-        return lane.Lane(edge, speed, length, allow, disallow)
+    def addLane(self, edge, speed, length, allow=None, disallow=None,
+                width=0):
+        return lane.Lane(edge, speed, length, allow, disallow, float(width))
 
     def addRoundabout(self, nodes, edges=None):
         r = roundabout.Roundabout(nodes, edges)
@@ -451,7 +452,8 @@ class NetReader(handler.ContentHandler):
                 float(attrs['speed']),
                 float(attrs['length']),
                 attrs.get('allow'),
-                attrs.get('disallow'))
+                attrs.get('disallow'),
+                attrs.get('width'))
             self._currentLane.setShape(convertShape(attrs.get('shape', '')))
         if name == 'junction':
             if attrs['id'][0] != ':':

--- a/tools/sumolib/net/lane.py
+++ b/tools/sumolib/net/lane.py
@@ -82,7 +82,7 @@ class Lane:
 
     """ Lanes from a sumo network """
 
-    def __init__(self, edge, speed, length, allow, disallow):
+    def __init__(self, edge, speed, length, allow, disallow, width):
         self._edge = edge
         self._speed = speed
         self._length = length
@@ -93,6 +93,7 @@ class Lane:
         self._outgoing = []
         self._params = {}
         self._allowed = get_allowed(allow, disallow)
+        self._width = width
         edge.addLane(self)
 
     def getSpeed(self):
@@ -100,6 +101,9 @@ class Lane:
 
     def getLength(self):
         return self._length
+
+    def getWidth(self):
+        return self._width
 
     def setShape(self, shape):
         """Set the shape of the lane


### PR DESCRIPTION
When checking the output of a conversion from OpenDrive files
missing lane data was required.
The optional attribute `width` in the XML `lane` element was needed,
but not parsed by the `sumolib.net`, previously 

**NOTE:** a default argument value in the `Lane.__init__()` might be wise to better maintain backwards compatibility, but was omitted to stay in line with the other optional attributes' arguments.